### PR TITLE
fix: 겨울 이미지 랜덤 추출 수정

### DIFF
--- a/src/main/java/com/mingles/metamingle/creativetool/query/application/service/CreativeToolService.java
+++ b/src/main/java/com/mingles/metamingle/creativetool/query/application/service/CreativeToolService.java
@@ -27,13 +27,14 @@ public class CreativeToolService {
 
         List<ImageResponse> imageResponses = new ArrayList<>();
 
-        Random random = new Random();
-        int randomNumber = random.nextInt(15);
+//        Random random = new Random();
+//        int randomNumber = random.nextInt(6);
 
         for (String technique : techniques) {
+            int i = 0;
             List<Image> images = imageRepository.findImagesByLocationAndTechnique(location, technique);
             if (!images.isEmpty()) {
-                imageResponses.add(new ImageResponse(images.get(randomNumber)));
+                imageResponses.add(new ImageResponse(images.get(i++)));
             }
         }
 


### PR DESCRIPTION
- 11/28 겨울이미지 랜덤 추출 관련 CreatorToolService 수정
- 15개 리스트 -> 6개로 개수 달려지면서 관련 로직 수정했습니다.
